### PR TITLE
deprecate `gcbool.h`

### DIFF
--- a/gc/gcbool.h
+++ b/gc/gcbool.h
@@ -1,16 +1,18 @@
 #pragma once
 
-typedef unsigned int BOOL;
-/*+----------------------------------------------------------------------------------------------+*/
-// alias type typedefs
-#define FIXED s32                                       ///< Alias type for sfp32
-/*+----------------------------------------------------------------------------------------------+*/
-#ifndef TRUE
-#define TRUE    1                                       ///< True
-#endif
-/*+----------------------------------------------------------------------------------------------+*/
-#ifndef FALSE
-#define FALSE   0                                       ///< False
-#endif
-/*+----------------------------------------------------------------------------------------------+*/
+#warning This header is deprecated, and remains only for backwards compatibility. \
+	<gccore.h> includes <stdbool.h>; you should switch to using that.
 
+#include <gccore.h>
+
+#ifndef BOOL
+#define BOOL	bool
+#endif
+
+#ifndef TRUE
+#define TRUE	true
+#endif
+
+#ifndef FALSE
+#define FALSE	false
+#endif

--- a/gc/gcmodplay.h
+++ b/gc/gcmodplay.h
@@ -19,22 +19,22 @@ typedef struct _modsndbuf {
 
 typedef struct _modplay {
 	MOD mod;
-	BOOL playing,paused;
-	BOOL bits,stereo,manual_polling;
+	bool playing,paused;
+	bool bits,stereo,manual_polling;
 	u32 playfreq,numSFXChans;
 	MODSNDBUF soundBuf;
 } MODPlay;
 
 void MODPlay_Init(MODPlay *mod);
 s32 MODPlay_SetFrequency(MODPlay *mod,u32 freq);
-void MODPlay_SetStereo(MODPlay *mod,BOOL stereo);
+void MODPlay_SetStereo(MODPlay *mod,bool stereo);
 s32 MODPlay_SetMOD(MODPlay *mod,const void *mem);
 void MODPlay_Unload(MODPlay *mod);
 s32 MODPlay_AllocSFXChannels(MODPlay *mod,u32 sfxchans);
 s32 MODPlay_Start(MODPlay *mod);
 s32 MODPlay_Stop(MODPlay *mod);
 s32 MODPlay_TriggerNote(MODPlay *mod,u32 chan,u8 inst,u16 freq,u8 vol);
-s32 MODPlay_Pause(MODPlay *mod,BOOL);
+s32 MODPlay_Pause(MODPlay *mod,bool);
 void MODPlay_SetVolume(MODPlay * mod, s32 musicvolume, s32 sfxvolume);
 
 #ifdef __cplusplus

--- a/gc/modplay/defines.h
+++ b/gc/modplay/defines.h
@@ -53,7 +53,6 @@ typedef union
     u16 aword;
   } union_word;
 
-
 typedef union
   {
 #ifdef LITTLE_ENDIAN
@@ -72,19 +71,6 @@ typedef union
     u32 adword;
   } union_dword;
 
-
-
-
-
-#ifndef BOOL
-#define BOOL  u32
-#endif
-#ifndef TRUE
-#define TRUE  1
-#endif
-#ifndef FALSE
-#define FALSE 0
-#endif
 #ifndef NULL
 #define NULL  0
 #endif

--- a/gc/modplay/modplay.h
+++ b/gc/modplay/modplay.h
@@ -46,13 +46,13 @@ typedef struct _modinstr
     u32 loop_start;   /* 026..027 */
     u32 loop_end;     /* 028..029 */
     u32 loop_length;
-    BOOL looped;
+    bool looped;
     s8 * data;
   } MOD_INSTR;
 
 typedef struct _mod
   {
-    BOOL loaded;
+    bool loaded;
     s8 name[21];
     MOD_INSTR instrument[31];
     s32 num_patterns;
@@ -68,7 +68,7 @@ typedef struct _mod
     s32 mixingbuflen;
     s32 shiftval;     /* Number of bits to lshift every mixed 16bit word by */
     /* Player variables */
-    BOOL channel_active[MAX_VOICES];
+    bool channel_active[MAX_VOICES];
     s32 patterndelay;
     s32 speed;
     s32 bpm;
@@ -100,7 +100,7 @@ typedef struct _mod
     u8 trem_basevol[MAX_VOICES];
     u8 trem_freq[MAX_VOICES];
     u8 trem_depth[MAX_VOICES];
-    BOOL glissando[MAX_VOICES];
+    bool glissando[MAX_VOICES];
     u8 trem_wave[MAX_VOICES];
     u8 vib_wave[MAX_VOICES];
 
@@ -120,8 +120,8 @@ typedef struct _mod
     u8 musicvolume;
     u8 sfxvolume;
     
-    BOOL set;
-    BOOL *notify;
+    bool set;
+    bool *notify;
 
   } MOD;
 

--- a/gc/ogc/aram.h
+++ b/gc/ogc/aram.h
@@ -202,13 +202,13 @@ void AR_Clear(u32 flag);
 
 
 /*! 
- * \fn BOOL AR_CheckInit(void)
+ * \fn bool AR_CheckInit(void)
  * \brief Get the ARAM subsystem initialization flag
  *
- * \return TRUE if the ARAM subsystem has been initialized(via AR_Init())<br>
- *         FALSE if the ARAM subsystem has not been initialized, or has been reset(via AR_Reset())
+ * \return true if the ARAM subsystem has been initialized(via AR_Init())<br>
+ *         false if the ARAM subsystem has not been initialized, or has been reset(via AR_Reset())
  */
-BOOL AR_CheckInit(void);
+bool AR_CheckInit(void);
 
 
 /*!

--- a/gc/ogc/aram.h
+++ b/gc/ogc/aram.h
@@ -38,7 +38,6 @@ distribution.
  */ 
 
 #include <gctypes.h>
-#include <gcbool.h>
 
 /*! 
  * \addtogroup dmamode ARAM DMA transfer direction

--- a/gc/ogc/cache.h
+++ b/gc/ogc/cache.h
@@ -315,8 +315,8 @@ u32 LCQueueWait(u32);
 void LCFlushQueue(void);
 void LCAlloc(void *,u32);
 void LCAllocNoInvalidate(void *,u32);
-void LCAllocOneTag(BOOL,void *);
-void LCAllocTags(BOOL,void *,u32);
+void LCAllocOneTag(bool,void *);
+void LCAllocTags(bool,void *,u32);
 
 #define LCGetBase()		((void*)LC_BASE)
 #ifdef __cplusplus

--- a/gc/ogc/cache.h
+++ b/gc/ogc/cache.h
@@ -39,7 +39,6 @@ distribution.
 */
 
 #include <gctypes.h>
-#include <gcbool.h>
 
 #define LC_BASEPREFIX		0xe000
 #define LC_BASE				(LC_BASEPREFIX<<16)

--- a/gc/ogc/lwp.h
+++ b/gc/ogc/lwp.h
@@ -99,13 +99,13 @@ s32 LWP_SuspendThread(lwp_t thethread);
 s32 LWP_ResumeThread(lwp_t thethread);
 
 
-/*! \fn BOOL LWP_ThreadIsSuspended(lwp_t thethread)
+/*! \fn bool LWP_ThreadIsSuspended(lwp_t thethread)
 \brief Test whether the given thread is suspended or not
 \param[in] thethread handle to the thread context which should be tested.
 
 \return TRUE or FALSE
 */
-BOOL LWP_ThreadIsSuspended(lwp_t thethread);
+bool LWP_ThreadIsSuspended(lwp_t thethread);
 
 
 /*! \fn lwp_t LWP_GetSelf(void)

--- a/gc/ogc/lwp.h
+++ b/gc/ogc/lwp.h
@@ -39,7 +39,6 @@ distribution.
 */ 
 
 #include <gctypes.h>
-#include <gcbool.h>
 
 #define LWP_CLOSED					-1
 #define LWP_SUCCESSFUL				0

--- a/gc/ogc/lwp_heap.h
+++ b/gc/ogc/lwp_heap.h
@@ -2,7 +2,6 @@
 #define __LWP_HEAP_H__
 
 #include <gctypes.h>
-#include <gcbool.h>
 #include "machine/asm.h"
 
 #define HEAP_BLOCK_USED					1

--- a/gc/ogc/lwp_heap.h
+++ b/gc/ogc/lwp_heap.h
@@ -45,7 +45,7 @@ typedef struct _heap_cntrl_st {
 
 u32 __lwp_heap_init(heap_cntrl *theheap,void *start_addr,u32 size,u32 pg_size);
 void* __lwp_heap_allocate(heap_cntrl *theheap,u32 size);
-BOOL __lwp_heap_free(heap_cntrl *theheap,void *ptr);
+bool __lwp_heap_free(heap_cntrl *theheap,void *ptr);
 u32 __lwp_heap_getinfo(heap_cntrl *theheap,heap_iblock *theinfo);
 
 #ifdef LIBOGC_INTERNAL

--- a/gc/ogc/lwp_watchdog.h
+++ b/gc/ogc/lwp_watchdog.h
@@ -2,7 +2,6 @@
 #define __LWP_WATCHDOG_H__
 
 #include <gctypes.h>
-#include <gcbool.h>
 
 #include "lwp_queue.h"
 #include <time.h>

--- a/gc/ogc/message.h
+++ b/gc/ogc/message.h
@@ -37,7 +37,6 @@ distribution.
 */ 
 
 #include <gctypes.h>
-#include <gcbool.h>
 
 #define MQ_BOX_NULL				0xffffffff
 

--- a/gc/ogc/message.h
+++ b/gc/ogc/message.h
@@ -84,7 +84,7 @@ s32 MQ_Init(mqbox_t *mqbox,u32 count);
 void MQ_Close(mqbox_t mqbox);
 
 
-/*! \fn BOOL MQ_Send(mqbox_t mqbox,mqmsg_t msg,u32 flags)
+/*! \fn bool MQ_Send(mqbox_t mqbox,mqmsg_t msg,u32 flags)
 \brief Sends a message to the given message queue.
 \param[in] mqbox mqbox_t handle to the message queue
 \param[in] msg message to send
@@ -92,10 +92,10 @@ void MQ_Close(mqbox_t mqbox);
 
 \return bool result
 */
-BOOL MQ_Send(mqbox_t mqbox,mqmsg_t msg,u32 flags);
+bool MQ_Send(mqbox_t mqbox,mqmsg_t msg,u32 flags);
 
 
-/*! \fn BOOL MQ_Jam(mqbox_t mqbox,mqmsg_t msg,u32 flags)
+/*! \fn bool MQ_Jam(mqbox_t mqbox,mqmsg_t msg,u32 flags)
 \brief Sends a message to the given message queue and jams it in front of the queue.
 \param[in] mqbox mqbox_t handle to the message queue
 \param[in] msg message to send
@@ -103,10 +103,10 @@ BOOL MQ_Send(mqbox_t mqbox,mqmsg_t msg,u32 flags);
 
 \return bool result
 */
-BOOL MQ_Jam(mqbox_t mqbox,mqmsg_t msg,u32 flags);
+bool MQ_Jam(mqbox_t mqbox,mqmsg_t msg,u32 flags);
 
 
-/*! \fn BOOL MQ_Receive(mqbox_t mqbox,mqmsg_t *msg,u32 flags)
+/*! \fn bool MQ_Receive(mqbox_t mqbox,mqmsg_t *msg,u32 flags)
 \brief Sends a message to the given message queue.
 \param[in] mqbox mqbox_t handle to the message queue
 \param[in] msg pointer to a mqmsg_t_t-type message to receive.
@@ -114,7 +114,7 @@ BOOL MQ_Jam(mqbox_t mqbox,mqmsg_t msg,u32 flags);
 
 \return bool result
 */
-BOOL MQ_Receive(mqbox_t mqbox,mqmsg_t *msg,u32 flags);
+bool MQ_Receive(mqbox_t mqbox,mqmsg_t *msg,u32 flags);
 
 #ifdef __cplusplus
 	}

--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -39,7 +39,6 @@ distribution.
 */
 
 #include <gctypes.h>
-#include <gcbool.h>
 #include <gcutil.h>
 #include <time.h>
 #include <ogc/lwp_queue.h>

--- a/gc/samplerate.h
+++ b/gc/samplerate.h
@@ -140,7 +140,7 @@ int src_set_ratio (SRC_STATE *state, double new_ratio) ;
 int src_reset (SRC_STATE *state) ;
 
 /*
-** Return TRUE if ratio is a valid conversion ratio, FALSE
+** Return true if ratio is a valid conversion ratio, false
 ** otherwise.
 */
 

--- a/libmodplay/gcmodplay.c
+++ b/libmodplay/gcmodplay.c
@@ -14,8 +14,8 @@
 #define STACKSIZE		8192
 #define SNDBUFFERSIZE	(5760)			//that's the maximum buffer size
 
-static BOOL thr_running = FALSE;
-static BOOL sndPlaying = FALSE;
+static bool thr_running = false;
+static bool sndPlaying = false;
 static MODSNDBUF sndBuffer;
 
 static u32 shiftVal = 0;
@@ -45,10 +45,10 @@ static void* player(void *arg)
 	u64 start;
 #endif
 
-	thr_running = TRUE;
-	while(sndPlaying==TRUE) {
+	thr_running = true;
+	while(sndPlaying==true) {
 		LWP_ThreadSleep(player_queue);
-		if(sndPlaying==TRUE) {
+		if(sndPlaying==true) {
 #ifdef _GCMOD_DEBUG
 			start = gettime();
 #endif
@@ -58,7 +58,7 @@ static void* player(void *arg)
 #endif
 		}
 	}
-	thr_running = FALSE;
+	thr_running = false;
 
 	return 0;
 }
@@ -154,7 +154,7 @@ static s32 SndBufStart(MODSNDBUF *sndbuf)
 	while(thr_running);
 
 	curr_audio = 0;
-	sndPlaying = TRUE;
+	sndPlaying = true;
 	if(LWP_CreateThread(&hplayer,player,NULL,player_stack,STACKSIZE,80)!=-1) {
 #ifndef __AESNDLIB_H__
 		AUDIO_RegisterDMACallback(dmaCallback);
@@ -165,7 +165,7 @@ static s32 SndBufStart(MODSNDBUF *sndbuf)
 #endif
 		return 1;
 	}
-	sndPlaying = FALSE;
+	sndPlaying = false;
 
 	return -1;
 }
@@ -180,14 +180,14 @@ static void SndBufStop()
 	AESND_SetVoiceStop(modvoice,true);
 #endif
 	curr_audio = 0;
-	sndPlaying = FALSE;
+	sndPlaying = false;
 	LWP_ThreadSignal(player_queue);
 	LWP_JoinThread(hplayer,NULL);
 }
 
 static s32 updateWaveFormat(MODPlay *mod)
 {
-	BOOL p = mod->playing;
+	bool p = mod->playing;
 	
 	if(p)
 		SndBufStop();
@@ -236,17 +236,17 @@ void MODPlay_Init(MODPlay *mod)
 	}
 #endif
 	MODPlay_SetFrequency(mod,48000);
-	MODPlay_SetStereo(mod,TRUE);
+	MODPlay_SetStereo(mod,true);
 
 	LWP_InitQueue(&player_queue);
 
-	sndPlaying = FALSE;
-	thr_running = FALSE;
+	sndPlaying = false;
+	thr_running = false;
 
-	mod->paused = FALSE;
-	mod->bits = TRUE;
+	mod->paused = false;
+	mod->bits = true;
 	mod->numSFXChans = 0;
-	mod->manual_polling = FALSE;
+	mod->manual_polling = false;
 }
 
 s32 MODPlay_SetFrequency(MODPlay *mod,u32 freq)
@@ -268,7 +268,7 @@ s32 MODPlay_SetFrequency(MODPlay *mod,u32 freq)
 	return -1;
 }
 
-void MODPlay_SetStereo(MODPlay *mod,BOOL stereo)
+void MODPlay_SetStereo(MODPlay *mod,bool stereo)
 {
 	if(stereo==mod->stereo) return;
 
@@ -301,7 +301,7 @@ s32 MODPlay_Start(MODPlay *mod)
 	updateWaveFormat(mod);
 	MOD_Start(&mod->mod);
 	if(SndBufStart(&mod->soundBuf)<0) return -1;
-	mod->playing = TRUE;
+	mod->playing = true;
 	return 0;
 }
 
@@ -310,7 +310,7 @@ s32 MODPlay_Stop(MODPlay *mod)
 	if(!mod->playing) return -1;
 
 	SndBufStop();
-	mod->playing = FALSE;
+	mod->playing = false;
 	return 0;
 }
 
@@ -325,7 +325,7 @@ s32 MODPlay_AllocSFXChannels(MODPlay *mod,u32 sfxchans)
 	return -1;
 }
 
-s32 MODPlay_Pause(MODPlay *mod,BOOL pause)
+s32 MODPlay_Pause(MODPlay *mod,bool pause)
 {
 	if(!mod->playing) return -1;
 	mod->paused = pause;

--- a/libmodplay/mixer.c
+++ b/libmodplay/mixer.c
@@ -59,7 +59,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                     else \
                       { \
                         playpos.adword = (mod->instrument[mod->instnum[voice]].loop_end-1)<<16; \
-                        mod->channel_active[voice] = FALSE; \
+                        mod->channel_active[voice] = false; \
                         break; \
                       } \
                   }

--- a/libmodplay/modplay.c
+++ b/libmodplay/modplay.c
@@ -260,12 +260,12 @@ void MOD_Free ( MOD * mod )
 
     MEM_SET ( mod, 0, sizeof(MOD) );
     
-    mod->loaded = FALSE;
+    mod->loaded = false;
   }
 #else
 void MOD_Free ( MOD * mod )
   {
-    mod->set = FALSE;
+    mod->set = false;
 
     if (!mod->loaded)
       return;
@@ -275,7 +275,7 @@ void MOD_Free ( MOD * mod )
     
     MEM_SET ( mod, 0, sizeof(MOD) );
     
-    mod->loaded = FALSE;
+    mod->loaded = false;
   }
 #endif
 
@@ -380,10 +380,10 @@ s32 MOD_SetMOD ( MOD * mod, u8 * mem )
         mod->instrument[i].loop_end = tmp + mod->instrument[i].loop_start;
 
         /* Is the sample looped ? */
-        mod->instrument[i].looped = TRUE;
+        mod->instrument[i].looped = true;
         if (tmp<=2)
           { /* No ! */
-            mod->instrument[i].looped = FALSE;
+            mod->instrument[i].looped = false;
             mod->instrument[i].loop_start = mod->instrument[i].loop_end =
               mod->instrument[i].length;
           }
@@ -422,7 +422,7 @@ s32 MOD_SetMOD ( MOD * mod, u8 * mem )
           }
       }
 
-    mod->set = TRUE;
+    mod->set = true;
 
     return 0;
   } 
@@ -490,7 +490,7 @@ s32 MOD_Load ( MOD * mod, const char * fname )
         MOD_Free ( mod );
         return -1;
       }
-    mod->loaded = TRUE;
+    mod->loaded = true;
 
     return 0;
   }
@@ -524,19 +524,19 @@ u8 getEffectOp ( MOD * mod, s32 patternline, s32 channel )
     return (data[3]);
   }
 
-BOOL triggerNote ( MOD * mod, s32 i, u8 instrument, u16 note, u8 effect )
+bool triggerNote ( MOD * mod, s32 i, u8 instrument, u16 note, u8 effect )
   {
-    BOOL ret = FALSE;
+    bool ret = false;
     if ((instrument!=0) && (note!=0) && (effect!=3) && (effect!=5))
       {
         mod->playpos[i] = 0;
         mod->instnum[i] = instrument-1;
         mod->sintabpos[i] = 0;
-        ret = TRUE;
+        ret = true;
       }
     if (note!=0)
       {
-        ret = TRUE;
+        ret = true;
         mod->channote[i] = note;
         if ((effect==3) || (effect==5))
           mod->portamento_to[i] = note;
@@ -550,7 +550,7 @@ BOOL triggerNote ( MOD * mod, s32 i, u8 instrument, u16 note, u8 effect )
       }
     if (instrument != 0)
       {
-        ret = TRUE;
+        ret = true;
         mod->volume[i] = mod->instrument[mod->instnum[i]].volume;
       }
     return ret;
@@ -745,7 +745,7 @@ u32 effect_handler ( MOD * mod )
                               {
                                 mod->retrigger_counter[i] = 0;
                                 mod->playpos[i] = 0;
-                                mod->channel_active[i] = TRUE;
+                                mod->channel_active[i] = true;
                                 retval |= 1<<i;
                               }
                           }
@@ -763,7 +763,7 @@ u32 effect_handler ( MOD * mod )
                             if (mod->speedcounter == (mod->effectop[i]&0x0f))
                               {
                                 triggerNote ( mod, i, mod->nextinstr[i], mod->nextnote[i], mod->effect[i] );
-                                mod->channel_active[i] = TRUE;
+                                mod->channel_active[i] = true;
                                 retval |= 1<<i;
                               }
                           }
@@ -779,8 +779,8 @@ u32 process ( MOD * mod )
   {
     s32 i;
     u32 retval = 0;
-    BOOL doPatternBreak=FALSE;
-    BOOL doPatternLoop=FALSE;
+    bool doPatternBreak=false;
+    bool doPatternLoop=false;
     u8 * patternData = getCurPatternData ( mod, mod->patternline, 0 );
 
     for (i=0;i<mod->num_voices;++i)
@@ -816,7 +816,7 @@ u32 process ( MOD * mod )
             if (triggerNote ( mod, i, mod->nextinstr[i], mod->nextnote[i], effect ))
               {
                 retval |= 1<<i;
-                mod->channel_active[i] = TRUE;
+                mod->channel_active[i] = true;
               }
           }
 
@@ -877,7 +877,7 @@ u32 process ( MOD * mod )
             case 0x0b:
               if (effect_operand<128)
                 {
-				  if(mod->notify) *mod->notify = TRUE;
+				  if(mod->notify) *mod->notify = true;
                   mod->songpos = effect_operand;
                   mod->patternline = 0;
                   return retval;
@@ -889,7 +889,7 @@ u32 process ( MOD * mod )
               mod->volume[i] = effect_operand;
               break;
             case 0x0d:
-              doPatternBreak=TRUE;
+              doPatternBreak=true;
               break;
             case 0x0e:
               switch ( (effect_operand>>4)&0x0f )
@@ -906,10 +906,10 @@ u32 process ( MOD * mod )
                     break;
                   case 0x03:
                     if ( (effect_operand&0x0f) == 0x00 )
-                      mod->glissando[i] = FALSE;
+                      mod->glissando[i] = false;
                     else
                     if ( (effect_operand&0x0f) == 0x01 )
-                      mod->glissando[i] = TRUE;
+                      mod->glissando[i] = true;
                     break;
                   case 0x04:
                     if ( (effect_operand&0x0f) < 8 )
@@ -923,14 +923,14 @@ u32 process ( MOD * mod )
                       mod->patternline_jumpto = mod->patternline;
                     else
                       {
-                        doPatternLoop = TRUE;
+                        doPatternLoop = true;
                         if (mod->patternline_jumpcount==0)
                           {
                             mod->patternline_jumpcount = effect_operand&0x0f;
                           } else
                           {
                             if (--mod->patternline_jumpcount==0)
-                              doPatternLoop = FALSE;
+                              doPatternLoop = false;
                           }
                       }
                     break;
@@ -986,7 +986,7 @@ u32 process ( MOD * mod )
         mod->patternline = 0;
         if (mod->songpos>=mod->song_length)
           {
-			if(mod->notify) *mod->notify = TRUE;
+			if(mod->notify) *mod->notify = true;
             mod->songpos = 0;
             mod->patternline = 0;
           }
@@ -1008,7 +1008,7 @@ u32 process ( MOD * mod )
           }
         if (mod->songpos>=mod->song_length)
           {
-			if(mod->notify) *mod->notify = TRUE;
+			if(mod->notify) *mod->notify = true;
             mod->songpos = 0;
             mod->patternline = 0;
           }
@@ -1032,10 +1032,10 @@ void MOD_Start ( MOD * mod )
         mod->vib_freq[i] = 0;
         mod->vib_depth[i] = 0;
         mod->last_effect[i] = 0;
-        mod->glissando[i] = FALSE;
+        mod->glissando[i] = false;
         mod->trem_wave[i] = 0;
         mod->vib_wave[i] = 0;
-        mod->channel_active[i] = FALSE;
+        mod->channel_active[i] = false;
       }
 
     mod->songpos = 0;
@@ -1167,7 +1167,7 @@ s32 MOD_TriggerNote ( MOD * mod, s32 channel, u8 instnum, u16 freq, u8 vol )
 
     if (instnum!=0xff)
       {
-        mod->channel_active[channel] = TRUE;
+        mod->channel_active[channel] = true;
         mod->playpos[channel] = 0;
         mod->instnum[channel] = instnum;
       }

--- a/libogc/aram.c
+++ b/libogc/aram.c
@@ -199,7 +199,7 @@ void AR_Clear(u32 flag)
 	}
 }
 
-BOOL AR_CheckInit(void)
+bool AR_CheckInit(void)
 {
 	return __ARInit_Flag;
 }

--- a/libogc/arqmgr.c
+++ b/libogc/arqmgr.c
@@ -49,7 +49,7 @@ typedef struct _arqm_info {
 	u32 aram_start;
 	u32 curr_read_offset;
 	u32 curr_aram_offset;
-	volatile BOOL polled;
+	volatile bool polled;
 } ARQM_Info;
 
 static u32 __ARQMStackLocation;
@@ -70,7 +70,7 @@ static void __ARQMPollCallback(ARQRequest *req)
 	if(i>=ARQM_STACKENTRIES) return;
 
 	ptr->callback = NULL;
-	ptr->polled = TRUE;
+	ptr->polled = true;
 }
 
 void ARQM_Init(u32 arambase,s32 len)
@@ -100,7 +100,7 @@ u32 ARQM_PushData(void *buffer,s32 len)
 		ptr = &__ARQMInfo[__ARQMStackLocation];
 		
 		_CPU_ISR_Disable(level);
-		ptr->polled = FALSE;
+		ptr->polled = false;
 		ptr->aram_start = __ARQMStackPointer[__ARQMStackLocation++];
 		__ARQMStackPointer[__ARQMStackLocation] = ptr->aram_start+rlen;
 		__ARQMFreeBytes -= rlen;
@@ -108,7 +108,7 @@ u32 ARQM_PushData(void *buffer,s32 len)
 		ARQ_PostRequestAsync(&ptr->arqhandle,__ARQMStackLocation-1,ARQ_MRAMTOARAM,ARQ_PRIO_HI,ptr->aram_start,(u32)buffer,rlen,__ARQMPollCallback);
 		_CPU_ISR_Restore(level);
 
-		while(ptr->polled==FALSE);
+		while(ptr->polled==false);
 		return (ptr->aram_start);
 	}
 	return 0;

--- a/libogc/cache.c
+++ b/libogc/cache.c
@@ -121,7 +121,7 @@ void LCAlloc(void *addr,u32 bytes)
 		__LCEnable();
 		_CPU_ISR_Restore(level);
 	}
-	LCAllocTags(TRUE,addr,cnt);
+	LCAllocTags(true,addr,cnt);
 }
 
 void LCAllocNoInvalidate(void *addr,u32 bytes)
@@ -135,7 +135,7 @@ void LCAllocNoInvalidate(void *addr,u32 bytes)
 		__LCEnable();
 		_CPU_ISR_Restore(level);
 	}
-	LCAllocTags(FALSE,addr,cnt);
+	LCAllocTags(false,addr,cnt);
 }
 #ifdef HW_RVL
 void L2Enhance(void)

--- a/libogc/card.c
+++ b/libogc/card.c
@@ -241,7 +241,7 @@ static vu16* const _viReg = (u16*)0xCC002000;
 /* new api */
 static s32 __card_onreset(s32 final)
 {
-	if(final==FALSE) {
+	if(final==false) {
 		if(CARD_Unmount(CARD_SLOTA)==-1) return 0;
 		if(CARD_Unmount(CARD_SLOTB)==-1) return 0;
 	}

--- a/libogc/cond.c
+++ b/libogc/cond.c
@@ -163,23 +163,23 @@ s32 LWP_CondInit(cond_t *cond)
 
 s32 LWP_CondWait(cond_t cond,mutex_t mutex)
 {
-	return __lwp_cond_waitsupp(cond,mutex,LWP_THREADQ_NOTIMEOUT,FALSE);
+	return __lwp_cond_waitsupp(cond,mutex,LWP_THREADQ_NOTIMEOUT,false);
 }
 
 s32 LWP_CondSignal(cond_t cond)
 {
-	return __lwp_cond_signalsupp(cond,FALSE);
+	return __lwp_cond_signalsupp(cond,false);
 }
 
 s32 LWP_CondBroadcast(cond_t cond)
 {
-	return __lwp_cond_signalsupp(cond,TRUE);
+	return __lwp_cond_signalsupp(cond,true);
 }
 
 s32 LWP_CondTimedWait(cond_t cond,mutex_t mutex,const struct timespec *abstime)
 {
 	u64 timeout = LWP_THREADQ_NOTIMEOUT;
-	bool timedout = FALSE;
+	bool timedout = false;
 
 	if(abstime) timeout = __lwp_wd_calc_ticks(abstime);
 	return __lwp_cond_waitsupp(cond,mutex,timeout,timedout);

--- a/libogc/console.c
+++ b/libogc/console.c
@@ -66,7 +66,7 @@ static const unsigned int color_table[] =
   0xFF80FF80,		// 37 bright white
 };
 
-static u32 do_xfb_copy = FALSE;
+static u32 do_xfb_copy = false;
 static struct _console_data_s stdcon;
 static struct _console_data_s *curr_con = NULL;
 static void *_console_buffer = NULL;
@@ -81,7 +81,7 @@ void __console_vipostcb(u32 retraceCnt)
 	u32 ycnt,xcnt, fb_stride;
 	u32 *fb,*ptr;
 
-	do_xfb_copy = TRUE;
+	do_xfb_copy = true;
 
 	ptr = curr_con->destbuffer;
 	fb = VIDEO_GetCurrentFramebuffer()+(curr_con->target_y*curr_con->tgt_stride) + curr_con->target_x*VI_DISPLAY_PIX_SZ;
@@ -96,7 +96,7 @@ void __console_vipostcb(u32 retraceCnt)
 		fb += fb_stride;
 	}
 
-	do_xfb_copy = FALSE;
+	do_xfb_copy = false;
 }
 
 
@@ -111,7 +111,7 @@ static void __console_drawc(int c)
 	unsigned int fgcolor, bgcolor;
 	unsigned int nextline;
 
-	if(do_xfb_copy==TRUE) return;
+	if(do_xfb_copy==true) return;
 	if(!curr_con) return;
 	con = curr_con;
 

--- a/libogc/dsp.c
+++ b/libogc/dsp.c
@@ -32,7 +32,6 @@ distribution.
 #include <stdlib.h>
 #include <stdio.h>
 #include "gcutil.h"
-#include <gcbool.h>
 #include "asm.h"
 #include "processor.h"
 #include "irq.h"
@@ -54,8 +53,8 @@ distribution.
 #define DSPCR_RES           0x0001        // reset DSP
 
 
-static u32 __dsp_inited = FALSE;
-static u32 __dsp_rudetask_pend = FALSE;
+static u32 __dsp_inited = false;
+static u32 __dsp_rudetask_pend = false;
 static DSPCallback __dsp_intcb = NULL;
 static dsptask_t *__dsp_currtask,*__dsp_lasttask,*__dsp_firsttask,*__dsp_rudetask,*tmp_task;
 
@@ -235,13 +234,13 @@ static void __dsp_def_taskcb(void)
 			if(__dsp_currtask->res_cb) __dsp_currtask->res_cb(__dsp_currtask);
 			break;
 		case 0xDCD10002:
-			if(__dsp_rudetask_pend==TRUE) {
+			if(__dsp_rudetask_pend==true) {
 				if(__dsp_rudetask==__dsp_currtask) {
 					DSP_SendMailTo(0xCDD10003);
 					while(DSP_CheckMailTo());
 
 					__dsp_rudetask = NULL;
-					__dsp_rudetask_pend = FALSE;
+					__dsp_rudetask_pend = false;
 					if(__dsp_currtask->res_cb) __dsp_currtask->res_cb(__dsp_currtask);
 				} else {
 					DSP_SendMailTo(0xCDD10001);
@@ -251,7 +250,7 @@ static void __dsp_def_taskcb(void)
 					__dsp_currtask->flags = DSPTASK_YIELD;
 					__dsp_currtask = __dsp_rudetask;
 					__dsp_rudetask = NULL;
-					__dsp_rudetask_pend = FALSE;
+					__dsp_rudetask_pend = false;
 				}
 			} else if(__dsp_currtask->next==NULL) {
 				if(__dsp_firsttask==__dsp_currtask) {
@@ -277,7 +276,7 @@ static void __dsp_def_taskcb(void)
 			}
 			break;
 		case 0xDCD10003:
-			if(__dsp_rudetask_pend==TRUE) {
+			if(__dsp_rudetask_pend==true) {
 				if(__dsp_currtask->done_cb) __dsp_currtask->done_cb(__dsp_currtask);
 				DSP_SendMailTo(0xCDD10001);
 				while(DSP_CheckMailTo());
@@ -286,7 +285,7 @@ static void __dsp_def_taskcb(void)
 				__dsp_removetask(__dsp_currtask);
 
 				__dsp_currtask = __dsp_rudetask;
-				__dsp_rudetask_pend = FALSE;
+				__dsp_rudetask_pend = false;
 				__dsp_rudetask = NULL;
 			} else if(__dsp_currtask->next==NULL) {
 				if(__dsp_firsttask==__dsp_currtask) {
@@ -329,7 +328,7 @@ void DSP_Init(void)
 	printf("DSP_Init()\n");
 #endif
 	_CPU_ISR_Disable(level);
-	if(__dsp_inited==FALSE) {
+	if(__dsp_inited==false) {
 		__dsp_intcb= __dsp_def_taskcb;
 
 		IRQ_Request(IRQ_DSP_DSP,__dsp_inthandler,NULL);
@@ -342,7 +341,7 @@ void DSP_Init(void)
 		__dsp_firsttask = NULL;
 		__dsp_lasttask = NULL;
 		tmp_task = NULL;
-		__dsp_inited = TRUE;
+		__dsp_inited = true;
 	}
 	_CPU_ISR_Restore(level);
 }
@@ -493,12 +492,12 @@ dsptask_t* DSP_AssertTask(dsptask_t *task)
 	_CPU_ISR_Disable(level);
 	if(task==__dsp_currtask) {
 		__dsp_rudetask = task;
-		__dsp_rudetask_pend = TRUE;
+		__dsp_rudetask_pend = true;
 		ret = task;
 	} else {
 		if(task->prio<__dsp_currtask->prio) {
 			__dsp_rudetask = task;
-			__dsp_rudetask_pend = TRUE;
+			__dsp_rudetask_pend = true;
 			if(__dsp_currtask->state==DSPTASK_RUN)
 				_dspReg[5] = ((_dspReg[5]&~(DSPCR_DSPINT|DSPCR_ARINT|DSPCR_AIINT))|DSPCR_PIINT);
 

--- a/libogc/dvd.c
+++ b/libogc/dvd.c
@@ -168,7 +168,7 @@ static u32 __dvd_autoinvalidation = 1;
 static u32 __dvd_cancellasterror = 0;
 static u32 __dvd_drivechecked = 0;
 static u32 __dvd_drivestate = 0;
-static u32 __dvd_extensionsenabled = TRUE;
+static u32 __dvd_extensionsenabled = true;
 static u32 __dvd_lastlen;
 static u32 __dvd_nextcmdnum;
 static u32 __dvd_workaround;
@@ -765,7 +765,7 @@ static void __dvd_stategettingerrorcb(s32 result)
 				// disable the extensions iff they're enabled and we were trying to read the disc ID
 				if(__dvd_executing->cmd==0x05) {
 					__dvd_lasterror = 0;
-					__dvd_extensionsenabled = FALSE;
+					__dvd_extensionsenabled = false;
 					DVD_LowSpinUpDrive(__dvd_stateretrycb);
 					return;
 				}
@@ -1548,7 +1548,7 @@ static void __dvd_statebusy(dvdcmdblk *block)
 			return;
 		case 16:
 			__dvd_lasterror = 0;
-			__dvd_extensionsenabled = TRUE;
+			__dvd_extensionsenabled = true;
 			DVD_LowSpinUpDrive(__dvd_statebusycb);
 			return;
 		case 17:
@@ -1646,7 +1646,7 @@ static void __dvd_statecoverclosed(void)
 		if(blk->cb) blk->cb(-4,blk);
 		__dvd_stateready();
 	} else {
-		__dvd_extensionsenabled = TRUE;
+		__dvd_extensionsenabled = true;
 		DVD_LowSpinUpDrive(__dvd_statecoverclosed_spinupcb);
 	}
 }

--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -222,7 +222,7 @@ static void waitForReload(void)
 		{
 			kprintf("\n\tReset\n\n\n");
 #if defined(HW_DOL)
-			SYS_ResetSystem(SYS_HOTRESET,0,FALSE);
+			SYS_ResetSystem(SYS_HOTRESET,0,false);
 #else
 			__reload ();
 #endif

--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -144,7 +144,7 @@ static sys_resetinfo __gx_resetinfo = {
 extern int printk(const char *fmt,...);
 #endif
 
-static __inline__ BOOL IsWriteGatherBufferEmpty(void)
+static __inline__ bool IsWriteGatherBufferEmpty(void)
 {
 	return !(mfwpar()&1);
 }
@@ -198,7 +198,7 @@ static __inline__ void __GX_FifoReadDisable(void)
 
 static s32 __gx_onreset(s32 final)
 {
-	if(final==FALSE) {
+	if(final==false) {
 		GX_Flush();
 		GX_AbortFrame();
 	}
@@ -346,7 +346,7 @@ static void __GX_CleanGPFifo(void)
 
 	_CPU_ISR_Disable(level);
 	__GX_FifoReadDisable();
-	__GX_WriteFifoIntEnable(FALSE,FALSE);
+	__GX_WriteFifoIntEnable(false,false);
 
 	gpfifo->rd_ptr = gpfifo->wt_ptr;
 	gpfifo->rdwt_dst = 0;
@@ -370,14 +370,14 @@ static void __GX_CleanGPFifo(void)
 		cpufifo->rdwt_dst = gpfifo->rdwt_dst;
 
 		_piReg[5] = (cpufifo->wt_ptr&0x1FFFFFE0);
-		__GX_WriteFifoIntEnable(TRUE,FALSE);
-		__GX_FifoLink(TRUE);
+		__GX_WriteFifoIntEnable(true,false);
+		__GX_FifoLink(true);
 	}
 	__gx->cpCRreg &= ~0x22;
 	_cpReg[1] = __gx->cpCRreg;
 	breakPtCB = NULL;
 
-	__GX_WriteFifoIntReset(TRUE,TRUE);
+	__GX_WriteFifoIntReset(true,true);
 	__GX_FifoReadEnable();
 	_CPU_ISR_Restore(level);
 }

--- a/libogc/lock_supp.c
+++ b/libogc/lock_supp.c
@@ -11,8 +11,6 @@
 #include "asm.h"
 #include "processor.h"
 #include "mutex.h"
-#include <gcbool.h>
-
 
 int __libogc_lock_init(int *lock,int recursive)
 {
@@ -22,7 +20,7 @@ int __libogc_lock_init(int *lock,int recursive)
 	if(!lock) return -1;
 	
 	*lock = 0;
-	ret = LWP_MutexInit(&retlck,(recursive?TRUE:FALSE));
+	ret = LWP_MutexInit(&retlck,(recursive?true:false));
 	if(ret==0) *lock = (int)retlck;
 
 	return ret;

--- a/libogc/lwp.c
+++ b/libogc/lwp.c
@@ -136,7 +136,7 @@ void __lwp_sysinit(void)
 
 	// create idle thread, is needed iff all threads are locked on a queue
 	_thr_idle = (lwp_cntrl*)__lwp_objmgr_allocate(&_lwp_thr_objects);
-	__lwp_thread_init(_thr_idle,NULL,0,255,0,TRUE);
+	__lwp_thread_init(_thr_idle,NULL,0,255,0,true);
 	_thr_executing = _thr_heir = _thr_idle;
 	__lwp_thread_start(_thr_idle,idle_func,NULL);
 	__lwp_objmgr_open(&_lwp_thr_objects,&_thr_idle->object);
@@ -144,24 +144,24 @@ void __lwp_sysinit(void)
 	// create main thread, as this is our entry point
 	// for every GC application.
 	_thr_main = (lwp_cntrl*)__lwp_objmgr_allocate(&_lwp_thr_objects);
-	__lwp_thread_init(_thr_main,__stack_end,((u32)__stack_addr-(u32)__stack_end),191,0,TRUE);
+	__lwp_thread_init(_thr_main,__stack_end,((u32)__stack_addr-(u32)__stack_end),191,0,true);
 	__lwp_thread_start(_thr_main,(void*)__crtmain,NULL);
 	__lwp_objmgr_open(&_lwp_thr_objects,&_thr_main->object);
 }
 
-BOOL __lwp_thread_isalive(lwp_t thr_id)
+bool __lwp_thread_isalive(lwp_t thr_id)
 {
-	if(thr_id==LWP_THREAD_NULL || LWP_OBJTYPE(thr_id)!=LWP_OBJTYPE_THREAD) return FALSE;
+	if(thr_id==LWP_THREAD_NULL || LWP_OBJTYPE(thr_id)!=LWP_OBJTYPE_THREAD) return false;
 
 	lwp_cntrl *thethread = (lwp_cntrl*)__lwp_objmgr_getnoprotection(&_lwp_thr_objects,LWP_OBJMASKID(thr_id));
 	
-	if(thethread) {  
+	if(thethread) {
 		u32 *stackbase = thethread->stack;
 		if(stackbase[0]==0xDEADBABE && !__lwp_statedormant(thethread->cur_state) && !__lwp_statetransient(thethread->cur_state))
-			return TRUE;
+			return true;
 	}
 	
-	return FALSE;
+	return false;
 }
 
 lwp_t __lwp_thread_currentid(void)
@@ -169,9 +169,9 @@ lwp_t __lwp_thread_currentid(void)
 	return _thr_executing->object.id;
 }
 
-BOOL __lwp_thread_exists(lwp_t thr_id)
+bool __lwp_thread_exists(lwp_t thr_id)
 {
-	if(thr_id==LWP_THREAD_NULL || LWP_OBJTYPE(thr_id)!=LWP_OBJTYPE_THREAD) return FALSE;
+	if(thr_id==LWP_THREAD_NULL || LWP_OBJTYPE(thr_id)!=LWP_OBJTYPE_THREAD) return false;
 	return (__lwp_objmgr_getnoprotection(&_lwp_thr_objects,LWP_OBJMASKID(thr_id))!=NULL);
 }
 
@@ -197,7 +197,7 @@ s32 LWP_CreateThread(lwp_t *thethread,void* (*entry)(void *),void *arg,void *sta
 	lwp_thread = __lwp_cntrl_allocate();
 	if(!lwp_thread) return -1;
 
-	status = __lwp_thread_init(lwp_thread,stackbase,stack_size,__lwp_priotocore(prio),0,TRUE);
+	status = __lwp_thread_init(lwp_thread,stackbase,stack_size,__lwp_priotocore(prio),0,true);
 	if(!status) {
 		__lwp_cntrl_free(lwp_thread);
 		__lwp_thread_dispatchenable();
@@ -241,7 +241,7 @@ s32 LWP_ResumeThread(lwp_t thethread)
 	if(!lwp_thread) return -1;
 
 	if(__lwp_statesuspended(lwp_thread->cur_state)) {
-		__lwp_thread_resume(lwp_thread,TRUE);
+		__lwp_thread_resume(lwp_thread,true);
 		__lwp_thread_dispatchenable();
 		return LWP_SUCCESSFUL;
 	}
@@ -269,7 +269,7 @@ void LWP_SetThreadPriority(lwp_t thethread,u32 prio)
 	lwp_thread = __lwp_cntrl_open(thethread);
 	if(!lwp_thread) return;
 
-	__lwp_thread_changepriority(lwp_thread,__lwp_priotocore(prio),TRUE);
+	__lwp_thread_changepriority(lwp_thread,__lwp_priotocore(prio),true);
 	__lwp_thread_dispatchenable();
 }
 
@@ -287,15 +287,15 @@ void LWP_Reschedule(u32 prio)
 	__lwp_thread_dispatchenable();
 }
 
-BOOL LWP_ThreadIsSuspended(lwp_t thethread)
+bool LWP_ThreadIsSuspended(lwp_t thethread)
 {
-	BOOL state;
+	bool state;
 	lwp_cntrl *lwp_thread;
 
 	lwp_thread = __lwp_cntrl_open(thethread);
-  	if(!lwp_thread) return FALSE;
+  	if(!lwp_thread) return false;
 	
-	state = (__lwp_statesuspended(lwp_thread->cur_state) ? TRUE : FALSE);
+	state = (__lwp_statesuspended(lwp_thread->cur_state) ? true : false);
 
 	__lwp_thread_dispatchenable();
 	return state;

--- a/libogc/lwp_heap.c
+++ b/libogc/lwp_heap.c
@@ -96,7 +96,7 @@ void* __lwp_heap_allocate(heap_cntrl *theheap,u32 size)
 	return ptr;
 }
 
-BOOL __lwp_heap_free(heap_cntrl *theheap,void *ptr)
+bool __lwp_heap_free(heap_cntrl *theheap,void *ptr)
 {
 	heap_block *block;
 	heap_block *next_block;
@@ -110,7 +110,7 @@ BOOL __lwp_heap_free(heap_cntrl *theheap,void *ptr)
 	block = __lwp_heap_usrblockat(ptr);
 	if(!__lwp_heap_blockin(theheap,block) || __lwp_heap_blockfree(block)) {
 		_CPU_ISR_Restore(level);
-		return FALSE;
+		return false;
 	}
 
 	dsize = __lwp_heap_blocksize(block);
@@ -118,14 +118,14 @@ BOOL __lwp_heap_free(heap_cntrl *theheap,void *ptr)
 	
 	if(!__lwp_heap_blockin(theheap,next_block) || (block->front_flag!=next_block->back_flag)) {
 		_CPU_ISR_Restore(level);
-		return FALSE;
+		return false;
 	}
 	
 	if(__lwp_heap_prev_blockfree(block)) {
 		prev_block = __lwp_heap_prevblock(block);
 		if(!__lwp_heap_blockin(theheap,prev_block)) {
 			_CPU_ISR_Restore(level);
-			return FALSE;
+			return false;
 		}
 		
 		if(__lwp_heap_blockfree(next_block)) {
@@ -156,7 +156,7 @@ BOOL __lwp_heap_free(heap_cntrl *theheap,void *ptr)
 	}
 	_CPU_ISR_Restore(level);
 
-	return TRUE;
+	return true;
 }
 
 u32 __lwp_heap_getinfo(heap_cntrl *theheap,heap_iblock *theinfo)

--- a/libogc/lwp_mutex.c
+++ b/libogc/lwp_mutex.c
@@ -52,8 +52,8 @@ u32 __lwp_mutex_surrender(lwp_mutex *mutex)
 
 	mutex->holder = NULL;
 	if(__lwp_mutex_isinheritprio(&mutex->atrrs) || __lwp_mutex_isprioceiling(&mutex->atrrs)) {
-		if(holder->res_cnt==0 && holder->real_prio!=holder->cur_prio) 
-			__lwp_thread_changepriority(holder,holder->real_prio,TRUE);
+		if(holder->res_cnt==0 && holder->real_prio!=holder->cur_prio)
+			__lwp_thread_changepriority(holder,holder->real_prio,true);
 	}
 	
 	if((thethread=__lwp_threadqueue_dequeue(&mutex->wait_queue))) {
@@ -74,7 +74,7 @@ void __lwp_mutex_seize_irq_blocking(lwp_mutex *mutex,u64 timeout)
 	exec = _thr_executing;
 	if(__lwp_mutex_isinheritprio(&mutex->atrrs)){
 		if(mutex->holder->cur_prio>exec->cur_prio)
-			__lwp_thread_changepriority(mutex->holder,exec->cur_prio,FALSE);
+			__lwp_thread_changepriority(mutex->holder,exec->cur_prio,false);
 	}
 
 	mutex->blocked_cnt++;
@@ -83,7 +83,7 @@ void __lwp_mutex_seize_irq_blocking(lwp_mutex *mutex,u64 timeout)
 	if(_thr_executing->wait.ret_code==LWP_MUTEX_SUCCESSFUL) {
 		if(__lwp_mutex_isprioceiling(&mutex->atrrs)) {
 			if(mutex->atrrs.prioceil<exec->cur_prio) 
-				__lwp_thread_changepriority(exec,mutex->atrrs.prioceil,FALSE);
+				__lwp_thread_changepriority(exec,mutex->atrrs.prioceil,false);
 		}
 	}
 	__lwp_thread_dispatchenable();

--- a/libogc/lwp_mutex.inl
+++ b/libogc/lwp_mutex.inl
@@ -55,7 +55,7 @@ static __inline__ u32 __lwp_mutex_seize_irq_trylock(lwp_mutex *mutex,u32 *isr_le
 			if(priocurr>prioceiling) {
 				__lwp_thread_dispatchdisable();
 				_CPU_ISR_Restore(level);
-				__lwp_thread_changepriority(mutex->holder,mutex->atrrs.prioceil,FALSE);
+				__lwp_thread_changepriority(mutex->holder,mutex->atrrs.prioceil,false);
 				__lwp_thread_dispatchenable();
 				return 0;
 			}

--- a/libogc/lwp_threadq.c
+++ b/libogc/lwp_threadq.c
@@ -491,7 +491,7 @@ u32 __lwp_threadqueue_extractproxy(lwp_cntrl *thethread)
 	state = thethread->cur_state;
 	if(__lwp_statewaitthreadqueue(state)) {
 		__lwp_threadqueue_extract(thethread->wait.queue,thethread);
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }

--- a/libogc/lwp_threads.c
+++ b/libogc/lwp_threads.c
@@ -177,10 +177,10 @@ void __thread_dispatch(void)
 
 	_CPU_ISR_Disable(level);
 	exec = _thr_executing;
-	while(_context_switch_want==TRUE) {
+	while(_context_switch_want==true) {
 		heir = _thr_heir;
 		_thread_dispatch_disable_level = 1;
-		_context_switch_want = FALSE;
+		_context_switch_want = false;
 		_thr_executing = heir;
 		_CPU_ISR_Restore(level);
 
@@ -246,7 +246,7 @@ void __lwp_rotate_readyqueue(u32 prio)
 		_thr_heir = (lwp_cntrl*)ready->first;
 
 	if(exec!=_thr_heir)
-		_context_switch_want = TRUE;
+		_context_switch_want = true;
 
 #ifdef _LWPTHREADS_DEBUG
 	kprintf("__lwp_rotate_readyqueue(%d,%p,%p)\n",prio,exec,_thr_heir);
@@ -270,9 +270,9 @@ void __lwp_thread_yield(void)
 		_CPU_ISR_Flash(level);
 		if(__lwp_thread_isheir(exec))
 			_thr_heir = (lwp_cntrl*)ready->first;
-		_context_switch_want = TRUE;
+		_context_switch_want = true;
 	} else if(!__lwp_thread_isheir(exec))
-		_context_switch_want = TRUE;
+		_context_switch_want = true;
 	_CPU_ISR_Restore(level);
 }
 
@@ -299,7 +299,7 @@ void __lwp_thread_resettimeslice(void)
 	if(__lwp_thread_isheir(exec))
 		_thr_heir = (lwp_cntrl*)ready->first;
 
-	_context_switch_want = TRUE;
+	_context_switch_want = true;
 	_CPU_ISR_Restore(level);
 }
 
@@ -330,7 +330,7 @@ void __lwp_thread_setstate(lwp_cntrl *thethread,u32 state)
 	if(__lwp_thread_isheir(thethread))
 		__lwp_thread_calcheir();
 	if(__lwp_thread_isexec(thethread))
-		_context_switch_want = TRUE;
+		_context_switch_want = true;
 #ifdef _LWPTHREADS_DEBUG
 	kprintf("__lwp_thread_setstate(%d,%p,%p,%08x)\n",_context_switch_want,_thr_heir,thethread,thethread->cur_state);
 #endif
@@ -355,7 +355,7 @@ void __lwp_thread_clearstate(lwp_cntrl *thethread,u32 state)
 				_thr_heir = thethread;
 				if(_thr_executing->is_preemptible
 					|| thethread->cur_prio==0)
-				_context_switch_want = TRUE;
+				_context_switch_want = true;
 			}
 		}
 	}
@@ -370,10 +370,10 @@ u32 __lwp_evaluatemode(void)
 	exec = _thr_executing;
 	if(!__lwp_stateready(exec->cur_state)
 		|| (!__lwp_thread_isheir(exec) && exec->is_preemptible)){
-		_context_switch_want = TRUE;
-		return TRUE;
+		_context_switch_want = true;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 void __lwp_thread_changepriority(lwp_cntrl *thethread,u32 prio,u32 prependit)
@@ -405,7 +405,7 @@ void __lwp_thread_changepriority(lwp_cntrl *thethread,u32 prio,u32 prependit)
 	
 	if(!(_thr_executing==_thr_heir)
 		&& _thr_executing->is_preemptible)
-		_context_switch_want = TRUE;
+		_context_switch_want = true;
 
 	_CPU_ISR_Restore(level);
 }
@@ -448,7 +448,7 @@ void __lwp_thread_suspend(lwp_cntrl *thethread)
 		__lwp_thread_calcheir();
 	
 	if(__lwp_thread_isexec(thethread))
-		_context_switch_want = TRUE;
+		_context_switch_want = true;
 
 	_CPU_ISR_Restore(level);
 }
@@ -483,7 +483,7 @@ void __lwp_thread_resume(lwp_cntrl *thethread,u32 force)
 	
 	_CPU_ISR_Disable(level);
 
-	if(force==TRUE)
+	if(force==true)
 		thethread->suspendcnt = 0;
 	else
 		thethread->suspendcnt--;
@@ -504,7 +504,7 @@ void __lwp_thread_resume(lwp_cntrl *thethread,u32 force)
 				_thr_heir = thethread;
 				if(_thr_executing->is_preemptible
 					|| thethread->cur_prio==0)
-				_context_switch_want = TRUE;
+				_context_switch_want = true;
 			}
 		}
 	}
@@ -563,7 +563,7 @@ void __lwp_thread_ready(lwp_cntrl *thethread)
 	__lwp_thread_calcheir();
 	heir = _thr_heir;
 	if(!(__lwp_thread_isexec(heir)) && _thr_executing->is_preemptible)
-		_context_switch_want = TRUE;
+		_context_switch_want = true;
 	
 	_CPU_ISR_Restore(level);
 }
@@ -585,11 +585,11 @@ u32 __lwp_thread_init(lwp_cntrl *thethread,void *stack_area,u32 stack_size,u32 p
 		act_stack_size = __lwp_stack_allocate(thethread,act_stack_size);
 		if(!act_stack_size) return 0;
 
-		thethread->stack_allocated = TRUE;
+		thethread->stack_allocated = true;
 	} else {
 		thethread->stack = stack_area;
 		act_stack_size = stack_size;
-		thethread->stack_allocated = FALSE;
+		thethread->stack_allocated = false;
 	}
 	thethread->stack_size = act_stack_size;
 
@@ -705,7 +705,7 @@ void __lwp_thread_startmultitasking(void)
 	__sys_state_set(SYS_STATE_BEGIN_MT);
 	__sys_state_set(SYS_STATE_UP);
 
-	_context_switch_want = FALSE;
+	_context_switch_want = false;
 	_thr_executing = _thr_heir;
 #ifdef _LWPTHREADS_DEBUG
 	kprintf("__lwp_start_multitasking(%p,%p)\n",_thr_executing,_thr_heir);
@@ -736,7 +736,7 @@ void __lwp_thread_coreinit(void)
 	__lwp_thread_dispatchinitialize();
 	__lwp_thread_inittimeslice();
 	
-	_context_switch_want = FALSE;
+	_context_switch_want = false;
 	_thr_executing = NULL;
 	_thr_heir = NULL;
 	_thr_allocated_fp = NULL;

--- a/libogc/lwp_wkspace.inl
+++ b/libogc/lwp_wkspace.inl
@@ -6,7 +6,7 @@ static __inline__ void* __lwp_wkspace_allocate(u32 size)
 	return __lwp_heap_allocate(&__wkspace_heap,size);
 }
 
-static __inline__ BOOL __lwp_wkspace_free(void *ptr)
+static __inline__ bool __lwp_wkspace_free(void *ptr)
 {
 	return __lwp_heap_free(&__wkspace_heap,ptr);
 }

--- a/libogc/malloc_lock.c
+++ b/libogc/malloc_lock.c
@@ -26,7 +26,7 @@ void __memlock_init(void)
 
 		attr.mode = LWP_MUTEX_FIFO;
 		attr.nest_behavior = LWP_MUTEX_NEST_ACQUIRE;
-		attr.onlyownerrelease = TRUE;
+		attr.onlyownerrelease = true;
 		attr.prioceil = 1;
 		__lwp_mutex_initialize(&mem_lock,&attr,LWP_MUTEX_UNLOCKED);
 	}
@@ -41,7 +41,7 @@ void __libogc_malloc_lock(struct _reent *r)
 	if(!initialized) return;
 
 	_CPU_ISR_Disable(level);
-	__lwp_mutex_seize(&mem_lock,MEMLOCK_MUTEX_ID,TRUE,LWP_THREADQ_NOTIMEOUT,level);
+	__lwp_mutex_seize(&mem_lock,MEMLOCK_MUTEX_ID,true,LWP_THREADQ_NOTIMEOUT,level);
 }
 
 void __libogc_malloc_unlock(struct _reent *r)
@@ -61,7 +61,7 @@ void __libogc_malloc_lock(struct _reent *ptr)
 	if(!initialized) return;
 
 	_CPU_ISR_Disable(level);
-	__lwp_mutex_seize(&mem_lock,MEMLOCK_MUTEX_ID,TRUE,LWP_THREADQ_NOTIMEOUT,level);
+	__lwp_mutex_seize(&mem_lock,MEMLOCK_MUTEX_ID,true,LWP_THREADQ_NOTIMEOUT,level);
 	ptr->_errno = _thr_executing->wait.ret_code;
 }
 

--- a/libogc/message.c
+++ b/libogc/message.c
@@ -118,49 +118,49 @@ void MQ_Close(mqbox_t mqbox)
 	__lwp_mqbox_free(mbox);
 }
 
-BOOL MQ_Send(mqbox_t mqbox,mqmsg_t msg,u32 flags)
+bool MQ_Send(mqbox_t mqbox,mqmsg_t msg,u32 flags)
 {
-	BOOL ret;
+	bool ret;
 	mqbox_st *mbox;
-	u32 wait = (flags==MQ_MSG_BLOCK)?TRUE:FALSE;
+	u32 wait = (flags==MQ_MSG_BLOCK)?true:false;
 
 	mbox = __lwp_mqbox_open(mqbox);
-	if(!mbox) return FALSE;
+	if(!mbox) return false;
 
-	ret = FALSE;
-	if(__lwpmq_submit(&mbox->mqueue,mbox->object.id,(void*)&msg,sizeof(mqmsg_t),LWP_MQ_SEND_REQUEST,wait,LWP_THREADQ_NOTIMEOUT)==LWP_MQ_STATUS_SUCCESSFUL) ret = TRUE;
+	ret = false;
+	if(__lwpmq_submit(&mbox->mqueue,mbox->object.id,(void*)&msg,sizeof(mqmsg_t),LWP_MQ_SEND_REQUEST,wait,LWP_THREADQ_NOTIMEOUT)==LWP_MQ_STATUS_SUCCESSFUL) ret = true;
 	__lwp_thread_dispatchenable();
 
 	return ret;
 }
 
-BOOL MQ_Receive(mqbox_t mqbox,mqmsg_t *msg,u32 flags)
+bool MQ_Receive(mqbox_t mqbox,mqmsg_t *msg,u32 flags)
 {
-	BOOL ret;
+	bool ret;
 	mqbox_st *mbox;
-	u32 tmp,wait = (flags==MQ_MSG_BLOCK)?TRUE:FALSE;
+	u32 tmp,wait = (flags==MQ_MSG_BLOCK)?true:false;
 
 	mbox = __lwp_mqbox_open(mqbox);
-	if(!mbox) return FALSE;
+	if(!mbox) return false;
 
-	ret = FALSE;
-	if(__lwpmq_seize(&mbox->mqueue,mbox->object.id,(void*)msg,&tmp,wait,LWP_THREADQ_NOTIMEOUT)==LWP_MQ_STATUS_SUCCESSFUL) ret = TRUE;
+	ret = false;
+	if(__lwpmq_seize(&mbox->mqueue,mbox->object.id,(void*)msg,&tmp,wait,LWP_THREADQ_NOTIMEOUT)==LWP_MQ_STATUS_SUCCESSFUL) ret = true;
 	__lwp_thread_dispatchenable();
 
 	return ret;
 }
 
-BOOL MQ_Jam(mqbox_t mqbox,mqmsg_t msg,u32 flags)
+bool MQ_Jam(mqbox_t mqbox,mqmsg_t msg,u32 flags)
 {
-	BOOL ret;
+	bool ret;
 	mqbox_st *mbox;
-	u32 wait = (flags==MQ_MSG_BLOCK)?TRUE:FALSE;
+	u32 wait = (flags==MQ_MSG_BLOCK)?true:false;
 
 	mbox = __lwp_mqbox_open(mqbox);
-	if(!mbox) return FALSE;
+	if(!mbox) return false;
 
-	ret = FALSE;
-	if(__lwpmq_submit(&mbox->mqueue,mbox->object.id,(void*)&msg,sizeof(mqmsg_t),LWP_MQ_SEND_URGENT,wait,LWP_THREADQ_NOTIMEOUT)==LWP_MQ_STATUS_SUCCESSFUL) ret = TRUE;
+	ret = false;
+	if(__lwpmq_submit(&mbox->mqueue,mbox->object.id,(void*)&msg,sizeof(mqmsg_t),LWP_MQ_SEND_URGENT,wait,LWP_THREADQ_NOTIMEOUT)==LWP_MQ_STATUS_SUCCESSFUL) ret = true;
 	__lwp_thread_dispatchenable();
 
 	return ret;

--- a/libogc/mutex.c
+++ b/libogc/mutex.c
@@ -110,7 +110,7 @@ s32 LWP_MutexInit(mutex_t *mutex,bool use_recursive)
 
 	attr.mode = LWP_MUTEX_FIFO;
 	attr.nest_behavior = use_recursive?LWP_MUTEX_NEST_ACQUIRE:LWP_MUTEX_NEST_ERROR;
-	attr.onlyownerrelease = TRUE;
+	attr.onlyownerrelease = true;
 	attr.prioceil = 1; //__lwp_priotocore(LWP_PRIO_MAX-1);
 	__lwp_mutex_initialize(&ret->mutex,&attr,LWP_MUTEX_UNLOCKED);
 
@@ -139,12 +139,12 @@ s32 LWP_MutexDestroy(mutex_t mutex)
 
 s32 LWP_MutexLock(mutex_t mutex)
 {
-	return __lwp_mutex_locksupp(mutex,LWP_THREADQ_NOTIMEOUT,TRUE);
+	return __lwp_mutex_locksupp(mutex,LWP_THREADQ_NOTIMEOUT,true);
 }
 
 s32 LWP_MutexTryLock(mutex_t mutex)
 {
-	return __lwp_mutex_locksupp(mutex,LWP_THREADQ_NOTIMEOUT,FALSE);
+	return __lwp_mutex_locksupp(mutex,LWP_THREADQ_NOTIMEOUT,false);
 }
 
 s32 LWP_MutexUnlock(mutex_t mutex)

--- a/libogc/network_wii.c
+++ b/libogc/network_wii.c
@@ -279,7 +279,7 @@ static void* net_malloc(u32 size)
 	return __lwp_heap_allocate(&__net_heap, size);
 }
 
-static BOOL net_free(void *ptr)
+static bool net_free(void *ptr)
 {
 	return __lwp_heap_free(&__net_heap, ptr);
 }

--- a/libogc/pad.c
+++ b/libogc/pad.c
@@ -81,7 +81,7 @@ static s32 __pad_onreset(s32 final)
 
 	if(__pad_samplingcallback!=NULL) PAD_SetSamplingCallback(NULL);
 
-	if(final==FALSE) {
+	if(final==false) {
 		ret = PAD_Sync();
 		if(__pad_recalibrated$207==0 && ret) {
 			__pad_recalibrated$207 = PAD_Recalibrate(0xf0000000);

--- a/libogc/sdgecko_io.c
+++ b/libogc/sdgecko_io.c
@@ -275,7 +275,7 @@ static void __exi_wait(s32 drv_no)
 
 static s32 __card_exthandler(s32 chn,s32 dev)
 {
-	_ioCardInserted[chn] = FALSE;
+	_ioCardInserted[chn] = false;
 	_ioFlag[chn] = NOT_INITIALIZED;
 	sdgecko_ejectedCB(chn);
 	return 1;
@@ -1142,22 +1142,22 @@ static bool __card_check(s32 drv_no)
 {
 	s32 ret;
 	
-	if(drv_no<0 || drv_no>=MAX_DRIVE) return FALSE;
+	if(drv_no<0 || drv_no>=MAX_DRIVE) return false;
 #ifdef _CARDIO_DEBUG	
 	printf("__card_check(%d)\n",drv_no);
 #endif
-	if(drv_no==2) return TRUE;
+	if(drv_no==2) return true;
 	while((ret=EXI_ProbeEx(drv_no))==0);
-	if(ret!=1) return FALSE;
+	if(ret!=1) return false;
 
 	if(!(EXI_GetState(drv_no)&EXI_FLAG_ATTACH)) {
-		if(EXI_Attach(drv_no,__card_exthandler)==0) return FALSE;
+		if(EXI_Attach(drv_no,__card_exthandler)==0) return false;
 #ifdef _CARDIO_DEBUG	
 		printf("__card_check(%d, attached)\n",drv_no);
 #endif
 		sdgecko_insertedCB(drv_no);
 	}
-	return TRUE;
+	return true;
 }
 
 static s32 __card_retrycb(s32 drv_no)
@@ -1196,7 +1196,7 @@ void sdgecko_initIODefault(void)
 	for(i=0;i<MAX_DRIVE;++i) {
 		_ioRetryCnt = 0;
 		_ioError[i] = 0;
-		_ioCardInserted[i] = FALSE;
+		_ioCardInserted[i] = false;
 		_ioFlag[i] = NOT_INITIALIZED;
 		_ioAddressingType[i] = CARD_IO_BYTE_ADDRESSING;
 		_initType[i] = TYPE_SD;
@@ -1220,7 +1220,7 @@ s32 sdgecko_initIO(s32 drv_no)
 	
 	_ioCardInserted[drv_no] = __card_check(drv_no);
 
-	if(_ioCardInserted[drv_no]==TRUE) {
+	if(_ioCardInserted[drv_no]==true) {
 		_ioWPFlag = 0;
 		_ioCardFreq[drv_no] = EXI_SPEED16MHZ;
 		_initType[drv_no] = TYPE_SD;
@@ -1420,8 +1420,8 @@ s32 sdgecko_doUnmount(s32 drv_no)
 {
 	if(drv_no<0 || drv_no>=MAX_DRIVE) return CARDIO_ERROR_NOCARD;
 
-	if(_ioCardInserted[drv_no]==TRUE) {
-		_ioCardInserted[drv_no] = FALSE;
+	if(_ioCardInserted[drv_no]==true) {
+		_ioCardInserted[drv_no] = false;
 		_ioFlag[drv_no] = NOT_INITIALIZED;
 		if(drv_no!=2) EXI_Detach(drv_no);
 		sdgecko_ejectedCB(drv_no);

--- a/libogc/semaphore.c
+++ b/libogc/semaphore.c
@@ -111,7 +111,7 @@ s32 LWP_SemWait(sem_t sem)
 	lwp_sem = __lwp_sema_open(sem);
 	if(!lwp_sem) return -1;
 
-	__lwp_sema_seize(&lwp_sem->sema,lwp_sem->object.id,TRUE,LWP_THREADQ_NOTIMEOUT);
+	__lwp_sema_seize(&lwp_sem->sema,lwp_sem->object.id,true,LWP_THREADQ_NOTIMEOUT);
 	__lwp_thread_dispatchenable();
 
 	switch(_thr_executing->wait.ret_code) {

--- a/libogc/si.c
+++ b/libogc/si.c
@@ -716,7 +716,7 @@ u32 SI_RegisterPollingHandler(RDSTHandler handler)
 	for(i=0;i<4;i++) {
 		if(rdstHandlers[i]==NULL) {
 			rdstHandlers[i] = handler;
-			SI_EnablePollingInterrupt(TRUE);
+			SI_EnablePollingInterrupt(true);
 			_CPU_ISR_Restore(level);
 			return 1;
 		}
@@ -737,7 +737,7 @@ u32 SI_UnregisterPollingHandler(RDSTHandler handler)
 			for(i=0;i<4;i++) {
 				if(rdstHandlers[i]!=NULL) break;
 			}
-			if(i>=4) SI_EnablePollingInterrupt(FALSE);
+			if(i>=4) SI_EnablePollingInterrupt(false);
 
 			_CPU_ISR_Restore(level);
 			return 1;

--- a/libogc/system.c
+++ b/libogc/system.c
@@ -354,7 +354,7 @@ static alarm_st* __lwp_syswd_allocate(void)
 
 static s32 __mem_onreset(s32 final)
 {
-	if(final==TRUE) {
+	if(final==true) {
 		_memReg[8] = 255;
 		__UnmaskIrq(IM_MEM0|IM_MEM1|IM_MEM2|IM_MEM3);
 	}
@@ -1127,20 +1127,20 @@ void SYS_ResetSystem(s32 reset,u32 reset_code,s32 force_menu)
 	__dsp_shutdown();
 
 	if(reset==SYS_SHUTDOWN) {
-		ret = __PADDisableRecalibration(TRUE);
+		ret = __PADDisableRecalibration(true);
 	}
 
-	while(__call_resetfuncs(FALSE)==0);
+	while(__call_resetfuncs(false)==0);
 
-	if(reset==SYS_HOTRESET && force_menu==TRUE) {
+	if(reset==SYS_HOTRESET && force_menu==true) {
 		sram = __SYS_LockSram();
 		sram->flags |= SRAM_BOOTIPL_BIT;
-		__SYS_UnlockSram(TRUE);
+		__SYS_UnlockSram(true);
 		while(!__SYS_SyncSram());
 	}
 
 	__exception_closeall();
-	__call_resetfuncs(TRUE);
+	__call_resetfuncs(true);
 
 	LCDisable();
 
@@ -1175,10 +1175,10 @@ void SYS_ResetSystem(s32 reset,u32 reset_code,s32 force_menu)
 	__dsp_shutdown();
 
 	if(reset==SYS_SHUTDOWN) {
-		ret = __PADDisableRecalibration(TRUE);
+		ret = __PADDisableRecalibration(true);
 	}
 
-	while(__call_resetfuncs(FALSE)==0);
+	while(__call_resetfuncs(false)==0);
 
 	switch(reset) {
 		case SYS_RESTART:
@@ -1212,7 +1212,7 @@ void SYS_ResetSystem(s32 reset,u32 reset_code,s32 force_menu)
 	__IOS_ShutdownSubsystems();
 
 	__exception_closeall();
-	__call_resetfuncs(TRUE);
+	__call_resetfuncs(true);
 
 	LCDisable();
 

--- a/lwip/network.c
+++ b/lwip/network.c
@@ -369,7 +369,7 @@ static err_t netconn_delete(struct netconn *conn)
 	mbox = conn->recvmbox;
 	conn->recvmbox = SYS_MBOX_NULL;
 	if(mbox!=SYS_MBOX_NULL) {
-		while(MQ_Receive(mbox,(mqmsg_t)&mem,MQ_MSG_NOBLOCK)==TRUE) {
+		while(MQ_Receive(mbox,(mqmsg_t)&mem,MQ_MSG_NOBLOCK)==true) {
 			if(mem!=NULL) {
 				if(conn->type==NETCONN_TCP)
 					pbuf_free((struct pbuf*)mem);
@@ -383,7 +383,7 @@ static err_t netconn_delete(struct netconn *conn)
 	mbox = conn->acceptmbox;
 	conn->acceptmbox = SYS_MBOX_NULL;
 	if(mbox!=SYS_MBOX_NULL) {
-		while(MQ_Receive(mbox,(mqmsg_t)&mem,MQ_MSG_NOBLOCK)==TRUE) {
+		while(MQ_Receive(mbox,(mqmsg_t)&mem,MQ_MSG_NOBLOCK)==true) {
 			if(mem!=NULL) netconn_delete((struct netconn*)mem);
 		}
 		MQ_Close(mbox);
@@ -1490,7 +1490,7 @@ s32 if_configex(struct in_addr *local_ip,struct in_addr *netmask,struct in_addr 
 	gw.addr = 0;
 
 	if (g_netinitiated < 3) {
-		if(use_dhcp==FALSE) {
+		if(use_dhcp==false) {
 			if( !gateway || gateway->s_addr==0
 				|| !local_ip || local_ip->s_addr==0
 				|| !netmask || netmask->s_addr==0 ) return -1;
@@ -1504,7 +1504,7 @@ s32 if_configex(struct in_addr *local_ip,struct in_addr *netmask,struct in_addr 
 			netif_set_up(pnet);
 			netif_set_default(pnet);
 	#if (LWIP_DHCP)
-			if(use_dhcp==TRUE) {
+			if(use_dhcp==true) {
 				//setup coarse timer
 				tb.tv_sec = DHCP_COARSE_TIMER_SECS;
 				tb.tv_nsec = 0;
@@ -1539,7 +1539,7 @@ s32 if_configex(struct in_addr *local_ip,struct in_addr *netmask,struct in_addr 
 		ret = net_init();
 
 		if (ret >= 0) {
-			if (use_dhcp == TRUE) {
+			if (use_dhcp == true) {
 				int retries = max_retries;
 				// wait for dhcp to bind
 				while ( g_hNetIF.dhcp->state != DHCP_BOUND && retries > 0 ) {
@@ -1582,7 +1582,7 @@ s32 if_config(char *local_ip, char *netmask, char *gateway,bool use_dhcp, int ma
 
 	if (ret<0) return ret;
 
-	if ( use_dhcp == TRUE ) {
+	if ( use_dhcp == true ) {
 		//copy back network addresses
 		if ( local_ip != NULL ) strcpy(local_ip, inet_ntoa( loc_ip ));
 		if ( netmask != NULL ) strcpy(netmask, inet_ntoa( mask));
@@ -2056,7 +2056,7 @@ s32 net_select(s32 maxfdp1,fd_set *readset,fd_set *writeset,fd_set *exceptset,st
 			return 0;
 		}
 
-		LWP_MutexInit(&sel_cb.cond_lck,FALSE);
+		LWP_MutexInit(&sel_cb.cond_lck,false);
 		LWP_CondInit(&sel_cb.cond);
 		sel_cb.next = selectcb_list;
 		selectcb_list = &sel_cb;

--- a/wiiuse/wpad.c
+++ b/wiiuse/wpad.c
@@ -118,7 +118,7 @@ static sys_resetinfo __wpad_resetinfo = {
 static s32 __wpad_onreset(s32 final)
 {
 	//printf("__wpad_onreset(%d)\n",final);
-	if(final==FALSE) {
+	if(final==false) {
 		WPAD_Shutdown();
 	}
 	return 1;


### PR DESCRIPTION
switch to `stdbool.h` across the codebase and deprecate `gcbool.h` for projects outside of libogc by issuing a compiler warning whenever it's `include`d (it may be a lot of warnings depending on how many files include it, but you could comment it out while taking 10 minutes to find and replace any references)

if you like uppercase `BOOL`/`TRUE`/`FALSE`, then... its still there? i guess?